### PR TITLE
Remove `run_second_cpp` ccache config option to fix CI builds

### DIFF
--- a/.github/scripts/utils.zsh/setup_ccache
+++ b/.github/scripts/utils.zsh/setup_ccache
@@ -10,7 +10,6 @@ if (( ${+commands[ccache]} )) {
 
   typeset -gx CCACHE_CONFIGPATH="${project_root}/.ccache.conf"
 
-  ccache --set-config=run_second_cpp=true
   ccache --set-config=direct_mode=true
   ccache --set-config=inode_cache=true
   ccache --set-config=compiler_check=content


### PR DESCRIPTION
MacOS builds are currently not working due to ccache 4.12 removing the `run_second_cpp` configuration option, which means an error occurs when the build scripts try to set that option.

See: https://ccache.dev/releasenotes.html#_ccache_4_12