### PR TITLE
Fix crash renaming nonexistent output file if no words spoken

### DIFF
--- a/src/transcription-filter-callbacks.cpp
+++ b/src/transcription-filter-callbacks.cpp
@@ -650,7 +650,8 @@ void recording_state_callback(enum obs_frontend_event event, void *data)
 				obs_log(gf_->log_level, "Recording stopped. Rename srt file.");
 				newPath.replace_extension(".srt");
 			} else {
-				obs_log(gf_->log_level, "Recording stopped. Rename transcript file.");
+				obs_log(gf_->log_level,
+					"Recording stopped. Rename transcript file.");
 				std::string newExtension = outputPath.extension().string();
 
 				if (newExtension == recordingPath.extension().string()) {
@@ -664,8 +665,7 @@ void recording_state_callback(enum obs_frontend_event event, void *data)
 			newPath = recordingPath.parent_path() / newPath.filename();
 
 			fs::rename(outputPath, newPath);
-		}
-		catch (std::filesystem::filesystem_error e) {
+		} catch (std::filesystem::filesystem_error e) {
 			obs_log(LOG_ERROR, "Error renaming output file - %s", e.what());
 		}
 	} else if (event == OBS_FRONTEND_EVENT_STREAMING_STARTING) {


### PR DESCRIPTION
Fixes: #187 
Fixes: #228 