### PR TITLE
Add ggml_abort callback function to handle errors

### DIFF
--- a/src/transcription-filter-callbacks.cpp
+++ b/src/transcription-filter-callbacks.cpp
@@ -25,6 +25,13 @@
 #include "translation/language_codes.h"
 #include "translation/cloud-translation/translation-cloud.h"
 
+bool whisper_abort_callback(void *data)
+{
+	// Seems like data is usually a string?
+	obs_log(LOG_ERROR, "Error in GGML processing - %s", (char *)(data));
+	return false;
+}
+
 void send_caption_to_source(const std::string &target_source_name, const std::string &caption,
 			    struct transcription_filter_data *gf)
 {

--- a/src/transcription-filter-callbacks.h
+++ b/src/transcription-filter-callbacks.h
@@ -6,6 +6,7 @@
 #include "transcription-filter-data.h"
 #include "whisper-utils/whisper-processing.h"
 
+bool whisper_abort_callback(void *data);
 void send_caption_to_source(const std::string &target_source_name, const std::string &str_copy,
 			    struct transcription_filter_data *gf);
 std::string send_sentence_to_translation(const std::string &sentence,

--- a/src/transcription-filter.cpp
+++ b/src/transcription-filter.cpp
@@ -423,6 +423,10 @@ void transcription_filter_update(void *data, obs_data_t *s)
 
 		apply_whisper_params_from_settings(gf->whisper_params, s);
 
+		if (gf->whisper_params.abort_callback == nullptr) {
+			gf->whisper_params.abort_callback = whisper_abort_callback;
+		}
+
 		if (!new_translate || gf->translation_model_index != "whisper-based-translation") {
 			const char *whisper_language_select =
 				obs_data_get_string(s, "whisper_language_select");


### PR DESCRIPTION
Apparently whisper.cpp has the ability to set a callback function that is called when there's an error in the GGML processing. It's poorly (not at all) documented, and seems to take a string argument, though the parameter is always `null` when it's been called, but having it set seems to prevent some crashes... somehow?? I guess it expects there to be one, so if there isn't we get a null pointer exception