### PR TITLE
Use CI preset for building Ubuntu to avoid building with system ICU

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -329,6 +329,7 @@ jobs:
       - name: Build Plugin 🧱
         uses: ./.github/actions/build-plugin
         with:
+          CI: 1
           target: x86_64
           config: ${{ needs.check-event.outputs.config }}
           acceleration: ${{ matrix.acceleration }}
@@ -336,6 +337,7 @@ jobs:
       - name: Package Plugin 📀
         uses: ./.github/actions/package-plugin
         with:
+          CI: 1
           package: ${{ fromJSON(needs.check-event.outputs.package) }}
           target: x86_64
           config: ${{ needs.check-event.outputs.config }}


### PR DESCRIPTION
ICU version changes a lot and the runtime version has to match the version built against, so we should go back to bundling a version we build ourselves for now.

Eventually we might consider making packages for various versions of Ubuntu/Debian, but this is the simplest fix

Fixes: #296 