### PR TITLE
fix: correct audio_ctx slider range (0–10 → 0–1500)

### DIFF
--- a/src/whisper-utils/whisper-params.cpp
+++ b/src/whisper-utils/whisper-params.cpp
@@ -168,7 +168,7 @@ void add_whisper_params_group_properties(obs_properties_t *ppts)
 	obs_properties_add_bool(g, "split_on_word", MT_("split_on_word"));
 	obs_properties_add_int(g, "max_tokens", MT_("max_tokens"), 0, 1000, 1);
 	obs_properties_add_bool(g, "debug_mode", MT_("debug_mode"));
-	obs_properties_add_int(g, "audio_ctx", MT_("audio_ctx"), 0, 10, 1);
+	obs_properties_add_int(g, "audio_ctx", MT_("audio_ctx"), 0, 1500, 1);
 	obs_properties_add_bool(g, "tdrz_enable", MT_("tdrz_enable"));
 	obs_properties_add_text(g, "suppress_regex", MT_("suppress_regex"), OBS_TEXT_DEFAULT);
 	obs_properties_add_text(g, "initial_prompt", MT_("initial_prompt"), OBS_TEXT_DEFAULT);


### PR DESCRIPTION
The `audio_ctx` parameter controls how many mel frames the Whisper encoder
processes. Each frame represents 10ms of audio, so the valid range is
0 (default, 1500 frames = 30s) to 1500.

The previous slider was bounded to [0, 10], making the entire usable range
inaccessible from the UI. A value of 10 corresponds to only 100ms of audio
context, which produces garbage output.

### Change

`obs_properties_add_int(g, "audio_ctx", ..., 0, 10, 1)`
→ `obs_properties_add_int(g, "audio_ctx", ..., 0, 1500, 1)`

### Effect

Users can now meaningfully reduce the audio context to save VRAM and
improve encoder latency on constrained hardware:

| Value | Context | Notes |
| ------- | --------- | ------- |
| 0 | 30s (default) | no change in behaviour |
| 512 | ~5s | reduced VRAM usage |
| 768 | ~7.7s | good balance for live captions |
| 1024 | ~10s | moderate reduction |