### PR TITLE
Fix unnecessary Whisper restarts on settings updates

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -26,3 +26,7 @@ target_include_directories(${TEST_EXEC_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 # install the tests to the release/test directory
 install(TARGETS ${TEST_EXEC_NAME} DESTINATION test)
+
+add_executable(${CMAKE_PROJECT_NAME}-backend-change-tests whisper-backend-change-test.cpp)
+target_include_directories(${CMAKE_PROJECT_NAME}-backend-change-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+install(TARGETS ${CMAKE_PROJECT_NAME}-backend-change-tests DESTINATION test)

--- a/src/tests/whisper-backend-change-test.cpp
+++ b/src/tests/whisper-backend-change-test.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+
+#include "whisper-utils/whisper-backend-utils.h"
+
+struct backend_change_test_case {
+	const char *name;
+	int current_backend_device;
+	int new_backend_device;
+	bool current_enable_flash_attn;
+	bool new_enable_flash_attn;
+	bool expected;
+};
+
+int main()
+{
+	const backend_change_test_case test_cases[] = {
+		{"same backend and Flash Attention", -1, -1, false, false, false},
+		{"different backend", -1, 0, false, false, true},
+		{"changed Flash Attention", -1, -1, false, true, true},
+		{"different backend and changed Flash Attention", -1, 0, false, true, true},
+	};
+
+	for (const auto &test_case : test_cases) {
+		const bool actual = is_whisper_backend_changed(
+			test_case.current_backend_device, test_case.new_backend_device,
+			test_case.current_enable_flash_attn, test_case.new_enable_flash_attn);
+		if (actual != test_case.expected) {
+			std::cerr << "Failed: " << test_case.name << " (expected " << test_case.expected
+				  << ", got " << actual << ")\n";
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/src/transcription-filter.cpp
+++ b/src/transcription-filter.cpp
@@ -25,6 +25,7 @@
 #include "transcription-utils.h"
 #include "model-utils/model-downloader.h"
 #include "whisper-utils/whisper-processing.h"
+#include "whisper-utils/whisper-backend-utils.h"
 #include "whisper-utils/whisper-language.h"
 #include "whisper-utils/whisper-model-utils.h"
 #include "whisper-utils/whisper-utils.h"
@@ -541,8 +542,8 @@ void transcription_filter_update(void *data, obs_data_t *s)
 
 	int new_backend_device = (int)obs_data_get_int(s, "backend_device");
 	bool enable_flash_attn = obs_data_get_bool(s, "enable_flash_attn");
-	bool whisper_backend_changed = (gf->gpu_device == new_backend_device) ||
-				       (enable_flash_attn != gf->enable_flash_attn);
+	bool whisper_backend_changed = is_whisper_backend_changed(
+		gf->gpu_device, new_backend_device, gf->enable_flash_attn, enable_flash_attn);
 	gf->gpu_device = new_backend_device;
 	gf->enable_flash_attn = enable_flash_attn;
 

--- a/src/whisper-utils/whisper-backend-utils.h
+++ b/src/whisper-utils/whisper-backend-utils.h
@@ -1,0 +1,11 @@
+#ifndef WHISPER_BACKEND_UTILS_H
+#define WHISPER_BACKEND_UTILS_H
+
+inline bool is_whisper_backend_changed(int current_backend_device, int new_backend_device,
+				       bool current_enable_flash_attn, bool new_enable_flash_attn)
+{
+	return current_backend_device != new_backend_device ||
+	       current_enable_flash_attn != new_enable_flash_attn;
+}
+
+#endif // WHISPER_BACKEND_UTILS_H


### PR DESCRIPTION
## Summary

Fix Whisper backend-change detection so unchanged backend settings do not force unnecessary Whisper restarts during unrelated LocalVocal property updates.

## Root cause

The previous comparison treated the backend as changed when the current and new backend devices were equal. That caused ordinary settings updates to call `update_whisper_model(gf, true)`, synchronously tearing down and reloading Whisper.

## Fix

Backend changes are now detected when either the backend device differs or Flash Attention differs. Focused regression coverage checks all four combinations of unchanged/changed backend and Flash Attention state.

## Validation

- Windows x64 Release `obs-localvocal` target builds successfully.
- `obs-localvocal-backend-change-tests` passes, including direct execution.
- OBS 32.2.2 portable runtime validation passed: unrelated settings caused no Whisper restarts, CPU -> Vulkan GPU caused exactly one intentional restart, and Vulkan GPU -> CPU caused exactly one intentional restart.
- Ordinary property updates became near-instantaneous after the fix.

## Existing test-suite limitation

The existing `obs-localvocal-tests` target cannot compile in this environment because `libavformat/avformat.h` is unavailable. The same failure was reproduced from an untouched checkout of the upstream base commit with the same toolchain, while the main plugin target built successfully in both candidate and control.
