### PR TITLE
fix: release OBS text source settings after caption updates

### DIFF
--- a/src/transcription-filter-callbacks.cpp
+++ b/src/transcription-filter-callbacks.cpp
@@ -44,8 +44,11 @@ void send_caption_to_source(const std::string &target_source_name, const std::st
 		return;
 	}
 	auto text_settings = obs_source_get_settings(target);
-	obs_data_set_string(text_settings, "text", caption.c_str());
-	obs_source_update(target, text_settings);
+	if (text_settings) {
+		obs_data_set_string(text_settings, "text", caption.c_str());
+		obs_source_update(target, text_settings);
+		obs_data_release(text_settings);
+	}
 	obs_source_release(target);
 }
 


### PR DESCRIPTION
`obs_source_get_settings()` returns a referenced `obs_data_t` object that must be released by the caller.

`send_caption_to_source()` currently updates the target text source and releases the `obs_source_t`, but does not release the settings reference returned by `obs_source_get_settings()`. Because this function can run repeatedly as captions are updated, those references can accumulate over time.

This change:

- releases `text_settings` after `obs_source_update()`;
- safely handles a null settings result;
- preserves the existing target-source cleanup and caption behavior.

I also audited the other first-party `obs_source_get_settings()` call sites and found their returned settings references already balanced.

### Validation

- backend-change test passes;
- `git diff --check` passes with the repository CRLF-aware whitespace setting;
- ownership paths were reviewed for balanced settings/source references;
- local Windows CMake reconfiguration succeeds, but the full plugin build could not complete because MSBuild stalled in the existing dependency build;
- no Linux or runtime OBS smoke test was available locally.