### PR TITLE
fix: prefer pkg-config for OpenBLAS detection on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ set_property(CACHE ACCELERATION PROPERTY STRINGS "generic" "nvidia" "amd")
 
 if(UNIX AND NOT APPLE)
   set(BLA_VENDOR OpenBLAS)
+  set(BLA_PREFER_PKGCONFIG ON)
+  set(BLA_PKGCONFIG_BLAS openblas)
   find_package(BLAS REQUIRED)
 endif()
 


### PR DESCRIPTION
The current Linux configuration forces CMake's OpenBLAS discovery through `FindBLAS`.

On the affected Ubuntu GitHub Actions environment, the direct OpenBLAS probe failed during configuration despite the OpenBLAS development packages being installed.

This change tells `FindBLAS` to prefer the installed `openblas.pc` pkg-config metadata by setting:

```cmake
set(BLA_PREFER_PKGCONFIG ON)
set(BLA_PKGCONFIG_BLAS openblas)
```

while retaining:

- `BLA_VENDOR OpenBLAS`;
- `find_package(BLAS REQUIRED)`;
- normal `FindBLAS` fallback behavior.

This avoids hard-coded library paths and does not change the required BLAS dependency or runtime behavior.

Validation:

- the same change was previously validated in the fork's GitHub Actions workflow;
- the previously failing Ubuntu build path passed with the pkg-config preference enabled;
- the local CMake module check passed;
- Windows CMake configure/generate completed successfully with the contribution branch;
- `git diff --check` passes.

The exact low-level reason the original direct `sgemm_` probe failed was not conclusively established.
